### PR TITLE
Fix TypeError on association field

### DIFF
--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -287,7 +287,7 @@ class EasyAdminTwigExtension extends AbstractExtension
             }
 
             // get the string representation of the associated *-to-one entity
-            if (method_exists($templateParameters['value'], '__toString')) {
+            if ($templateParameters['value'] && method_exists($templateParameters['value'], '__toString')) {
                 $templateParameters['value'] = (string) $templateParameters['value'];
             } elseif (null !== $primaryKeyValue) {
                 $templateParameters['value'] = sprintf('%s #%s', $targetEntityConfig['name'], $primaryKeyValue);


### PR DESCRIPTION
A TypeError occurs, when the $templateParameters['value'] is null.

Error message:
`method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given`

